### PR TITLE
small changes to the Sheets APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs 0.7.2",
- "sheets 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sheets 0.2.0",
  "slack_api",
  "tokio",
  "toml",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "cio-api"
 version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/cio?branch=master#974c15952b4d1679fafb4bd7c2cdc2f020e6fa5c"
+source = "git+https://github.com/oxidecomputer/cio?branch=master#050fa46c78177222e25949c8004aba7429d7ba61"
 dependencies = [
  "acme-lib",
  "airtable-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -634,7 +634,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs 0.7.2",
- "sheets 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sheets 0.1.6",
  "slack_api",
  "tokio",
  "toml",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "constant_time_eq"
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "15d658711a12632b5574c8d5b3fc5d2f0d2f87b9fbf9237ee0f759b88bb6bdec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -930,23 +930,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "16d3514d243331d8acde56bfcf45d0147aabbda853c2f49dce081ea85f9a7220"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
+ "strsim 0.10.0",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "44f63c369ef0c17ad17585d31d5f2bf10dece2710bf0766e01db57a6f9849a2e"
 dependencies = [
  "darling_core",
  "quote",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/cio?branch=master#974c15952b4d1679fafb4bd7c2cdc2f020e6fa5c"
+source = "git+https://github.com/oxidecomputer/cio?branch=master#050fa46c78177222e25949c8004aba7429d7ba61"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2218,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2369,12 +2369,12 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -2389,9 +2389,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
 dependencies = [
  "autocfg",
  "cc",
@@ -2451,9 +2451,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "paste"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7151b083b0664ed58ed669fcdd92f01c3d2fdbf10af4931a301474950b52bfa9"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
 
 [[package]]
 name = "pem"
@@ -3314,6 +3314,8 @@ dependencies = [
 [[package]]
 name = "sheets"
 version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cae652c06e31b3c38685c6e8da4199ab593f25bdab94a23793dc69388c66d4"
 dependencies = [
  "reqwest",
  "serde",
@@ -3322,9 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "sheets"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cae652c06e31b3c38685c6e8da4199ab593f25bdab94a23793dc69388c66d4"
+version = "0.2.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3611,9 +3611,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -3809,9 +3809,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes",
  "fnv",
@@ -4179,9 +4179,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec-arena"
@@ -4356,7 +4356,7 @@ dependencies = [
  "sendgrid-api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
- "sheets 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sheets 0.1.6",
  "tokio",
  "tracing",
  "tracing-attributes",

--- a/cio/Cargo.toml
+++ b/cio/Cargo.toml
@@ -47,8 +47,8 @@ sendgrid-api = "^0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.7"
-sheets = "^0.1.0"
 slack_api = "0.23.0"
+sheets = { path = "../sheets/" }
 tokio = { version = "0.2", features = ["macros", "rt-threaded"] }
 toml = "0.5"
 tracing = "^0.1"

--- a/cio/src/applicants.rs
+++ b/cio/src/applicants.rs
@@ -323,7 +323,7 @@ pub async fn get_raw_applicants() -> Vec<NewApplicant> {
     let mut applicants: Vec<NewApplicant> = Default::default();
     for (sheet_name, sheet_id) in get_sheets_map() {
         // Get the values in the sheet.
-        let sheet_values = sheets_client.get_values(&sheet_id, "Form Responses 1!A1:S1000".to_string()).await.unwrap();
+        let sheet_values = sheets_client.get_values(&sheet_id, "Form Responses 1!A1:S1000").await.unwrap();
         let values = sheet_values.values.unwrap();
 
         if values.is_empty() {

--- a/cio/src/models.rs
+++ b/cio/src/models.rs
@@ -342,7 +342,7 @@ impl NewApplicant {
             let mut colmn = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars();
             let rng = format!("{}{}", colmn.nth(sent_email_received_column_index).unwrap().to_string(), row_index);
 
-            sheets_client.update_values(&self.sheet_id, &rng, vec!(vec!("TRUE".to_string())), None).await.unwrap();
+            sheets_client.update_values(&self.sheet_id, &rng, vec![vec!["TRUE".to_string()]], None).await.unwrap();
 
             println!("[applicant] sent email to {} that we received their application", self.email);
         }

--- a/cio/src/models.rs
+++ b/cio/src/models.rs
@@ -342,7 +342,7 @@ impl NewApplicant {
             let mut colmn = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars();
             let rng = format!("{}{}", colmn.nth(sent_email_received_column_index).unwrap().to_string(), row_index);
 
-            sheets_client.update_values(&self.sheet_id, &rng, "TRUE".to_string()).await.unwrap();
+            sheets_client.update_values(&self.sheet_id, &rng, vec!(vec!("TRUE".to_string())), None).await.unwrap();
 
             println!("[applicant] sent email to {} that we received their application", self.email);
         }

--- a/sheets/Cargo.toml
+++ b/sheets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sheets"
 description = "An API client for Google Sheets"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Jess Frazelle <jess@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/sheets/src/lib.rs
+++ b/sheets/src/lib.rs
@@ -33,7 +33,7 @@
  *     let sheets_client = Sheets::new(token);
  *
  *     // Get the values in the sheet.
- *     let sheet_values = sheets_client.get_values("sheet_id", "Form Responses 1!A1:S1000".to_string()).await.unwrap();
+ *     let sheet_values = sheets_client.get_values("sheet_id", "Form Responses 1!A1:S1000").await.unwrap();
  *     let values = sheet_values.values.unwrap();
  *
  *     if values.is_empty() {
@@ -121,11 +121,12 @@ impl Sheets {
     }
 
     /// Get values.
-    pub async fn get_values(&self, sheet_id: &str, range: String) -> Result<ValueRange, APIError> {
+    pub async fn get_values(&self, sheet_id: &str, range: &str) -> Result<ValueRange, APIError> {
         // Build the request.
         let request = self.request(
             Method::GET,
-            format!("spreadsheets/{}/values/{}", sheet_id.to_string(), range),
+            format!("spreadsheets/{}/values/{}",
+                    sheet_id.to_string(), range.to_string()),
             (),
             Some(vec![
                 ("valueRenderOption", "FORMATTED_VALUE".to_string()),
@@ -153,7 +154,7 @@ impl Sheets {
     /// The `cell_name` is something like `A1` and what is returned is a string representation of
     /// the cell's value.
     pub async fn get_value(&self, sheet_id: &str, cell_name: String) -> Result<String, APIError> {
-        let value_range = self.get_values(sheet_id, cell_name).await.unwrap();
+        let value_range = self.get_values(sheet_id, &cell_name).await.unwrap();
         let values = value_range.values.unwrap_or_default();
         if values.is_empty() {
             return Ok(String::new());

--- a/sheets/src/lib.rs
+++ b/sheets/src/lib.rs
@@ -168,15 +168,20 @@ impl Sheets {
     }
 
     /// Update values.
-    pub async fn update_values(&self, sheet_id: &str, range: &str, value: String) -> Result<UpdateValuesResponse, APIError> {
+    pub async fn update_values(&self, sheet_id: &str, range: &str, values: Vec<Vec<String>>, major_dimension: Option<String>) -> Result<UpdateValuesResponse, APIError> {
+        let url = format!(
+            "spreadsheets/{}/values/{}",
+            sheet_id.to_string(),
+            range.to_string()
+        );
         // Build the request.
         let request = self.request(
             Method::PUT,
-            format!("spreadsheets/{}/values/{}", sheet_id.to_string(), range.to_string()),
+            url,
             ValueRange {
                 range: Some(range.to_string()),
-                values: Some(vec![vec![value]]),
-                major_dimension: None,
+                values: Some(values),
+                major_dimension: major_dimension,
             },
             Some(vec![
                 ("valueInputOption", "USER_ENTERED".to_string()),

--- a/sheets/src/lib.rs
+++ b/sheets/src/lib.rs
@@ -125,8 +125,7 @@ impl Sheets {
         // Build the request.
         let request = self.request(
             Method::GET,
-            format!("spreadsheets/{}/values/{}",
-                    sheet_id.to_string(), range.to_string()),
+            format!("spreadsheets/{}/values/{}", sheet_id.to_string(), range.to_string()),
             (),
             Some(vec![
                 ("valueRenderOption", "FORMATTED_VALUE".to_string()),
@@ -170,11 +169,7 @@ impl Sheets {
 
     /// Update values.
     pub async fn update_values(&self, sheet_id: &str, range: &str, values: Vec<Vec<String>>, major_dimension: Option<String>) -> Result<UpdateValuesResponse, APIError> {
-        let url = format!(
-            "spreadsheets/{}/values/{}",
-            sheet_id.to_string(),
-            range.to_string()
-        );
+        let url = format!("spreadsheets/{}/values/{}", sheet_id.to_string(), range.to_string());
         // Build the request.
         let request = self.request(
             Method::PUT,


### PR DESCRIPTION
Hi!
I'm using your sheets crate and I wanted to update more than on cells but couldn't with the current API.
I've changed it to be able to do so. While I was at it, I've also changed `Sheets::get_values()` to be more regular.
I've bumped the version of the crate due to those API changes and made `cio/Cargo.toml` use the local version of the sheets crate.
I've patched the existing calls to reflect those changes.

I've made multiple commits so that it's easier to pick one or more of those changes.