### PR TITLE
Balancing scorers

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Description from second commit (first one is a small usability fix for the build):

This tries to ensure that people get roughly the same number of assigned
applicants. Previously the code was doing sampling-with-replacement to
choose reviewers, so the fact that a reviewer had just been assigned
didn't change its probability of being chosen next. This switches it to
without-replacement until the deck of reviewers runs empty.

Reviewers are _not_ reshuffled when it runs empty to continue the same
load distribution.