### PR TITLE
Properly annotate the fields query paramter as an array

### DIFF
--- a/airtable/src/lib.rs
+++ b/airtable/src/lib.rs
@@ -138,7 +138,7 @@ impl Airtable {
     pub async fn list_records<T: DeserializeOwned>(&self, table: &str, view: &str, fields: Vec<&str>) -> Result<Vec<Record<T>>, APIError> {
         let mut params = vec![("pageSize", "100".to_string()), ("view", view.to_string())];
         for field in fields {
-            params.push(("fields", field.to_string()));
+            params.push(("fields[]", field.to_string()));
         }
 
         // Build the request.


### PR DESCRIPTION
The airtable API will interpret multiple fields parameters as an array without the brackets,
but if you only ask for one field it fails. With this change, asking for one field
works.