### PR TITLE
Modify calendar event APIs to be quarterly.

### DIFF
--- a/cio/src/huddles.rs
+++ b/cio/src/huddles.rs
@@ -482,8 +482,8 @@ pub async fn sync_huddles(db: &Database, company: &Company) {
 
         // Create Airtable records for any future calendar dates.
         for (date, event) in gcal_events {
-            // Four weeks from now.
-            let in_range = Utc::now().checked_add_signed(Duration::weeks(4)).unwrap();
+            // Create events up to one quarter in advance.
+            let in_range = Utc::now().checked_add_signed(Duration::weeks(13)).unwrap();
             if date > Utc::now().date().naive_utc() && date <= in_range.date().naive_utc() {
                 // We are in the future.
                 // Create an Airtable record.

--- a/gsuite/src/lib.rs
+++ b/gsuite/src/lib.rs
@@ -736,8 +736,7 @@ impl GSuite {
                 ("maxResults", "2500"),
                 ("showDeleted", "true"),
                 ("q", query),
-                // This is one week into the future.
-                ("timeMax", &Utc::now().checked_add_signed(Duration::weeks(4)).unwrap().to_rfc3339()),
+                ("timeMax", &Utc::now().checked_add_signed(Duration::weeks(13)).unwrap().to_rfc3339()),
             ]),
         );
 
@@ -797,7 +796,7 @@ impl GSuite {
             Some(&[
                 ("maxResults", "2500"),
                 ("showDeleted", "true"),
-                ("timeMax", &Utc::now().checked_add_signed(Duration::weeks(4)).unwrap().to_rfc3339()),
+                ("timeMax", &Utc::now().checked_add_signed(Duration::weeks(13)).unwrap().to_rfc3339()),
             ]),
         );
 


### PR DESCRIPTION
TL;DR: It's useful to be able to plan meetings
which are up to a few months in advance.

Admittedly, this could become another config,
but bumping this constant will let me schedule
the Control Plane demos happening in the
next couple months.