### PR TITLE
fix: use non-blocking sleep

### DIFF
--- a/cio/src/certs.rs
+++ b/cio/src/certs.rs
@@ -4,7 +4,7 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     str::from_utf8,
-    thread, time,
+    time,
 };
 
 use acme_lib::{create_p384_key, persist::FilePersist, Directory, DirectoryUrl};
@@ -196,7 +196,7 @@ impl NewCertificate {
             // TODO: make this less awful than a sleep.
             info!("validating the proof...");
             let dur = time::Duration::from_secs(10);
-            thread::sleep(dur);
+            tokio::time::sleep(dur).await;
 
             // After the TXT record is accessible, the calls
             // this to tell the ACME API to start checking the

--- a/cio/src/configs.rs
+++ b/cio/src/configs.rs
@@ -2,7 +2,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     str::from_utf8,
-    thread, time,
+    time,
 };
 
 use anyhow::{bail, Result};
@@ -1824,7 +1824,7 @@ pub async fn sync_users(
             // TODO: this is horrible, but we will sleep here to allow the terraform
             // job to run.
             // We also need a better way to ensure the terraform job passed...
-            thread::sleep(time::Duration::from_secs(120));
+            tokio::time::sleep(time::Duration::from_secs(120)).await;
 
             // The user did not already exist in the database.
             // We should send them an email about setting up their account.

--- a/cio/src/gsuite.rs
+++ b/cio/src/gsuite.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    thread, time,
+    time,
 };
 
 use anyhow::{bail, Result};
@@ -414,7 +414,7 @@ pub async fn update_google_group_settings(ggs: &GoogleGroupsSettings, group: &Gr
     let mut result = ggs.groups().get(google_groups_settings::types::Alt::Json, &email).await;
     if result.is_err() {
         // Try again.
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         result = ggs.groups().get(google_groups_settings::types::Alt::Json, &email).await;
     }
     let mut settings = result?;
@@ -441,7 +441,7 @@ pub async fn update_google_group_settings(ggs: &GoogleGroupsSettings, group: &Gr
         .await;
     if result2.is_err() {
         // Try again.
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         ggs.groups()
             .update(google_groups_settings::types::Alt::Json, &email, &settings)
             .await?;


### PR DESCRIPTION
Replace usages of blocking `std::thread::sleep`
with async `tokio::time::sleep` to unblock the event loop.
