### PR TITLE
Use date committed instead of date authored

### DIFF
--- a/cio/src/rfds.rs
+++ b/cio/src/rfds.rs
@@ -671,7 +671,7 @@ impl RFD {
             .await
         {
             let commit = commits.get(0).unwrap();
-            self.commit_date = commit.commit.author.as_ref().unwrap().date.parse()?;
+            self.commit_date = commit.commit.committer.as_ref().unwrap().date.parse()?;
         }
 
         // Parse the HTML.


### PR DESCRIPTION
I was poking around cio and I noticed that the `commit_date` of RFD's is determined by the `author` timestamp from the `list_commits` API. That corresponds to when the file was changed but not when that change was merged. Given that, you can end up with the updated date in the rendered RFD being sometime before the latest committed change. 

For example, RFD1's latest commit is authored at 2021-05-06.
```json
"commit": {
      "author": {
        "name": "Dan Cross",
        "email": "cross@oxidecomputer.com",
        "date": "2021-05-06T15:20:56Z"
      },
      "committer": {
        "name": "Dan Cross",
        "email": "crossd@gmail.com",
        "date": "2021-05-12T17:17:39Z"
      }
}
```

Whereas the second to last commit's author date is _after_ the first's. It was just merged before. 
```json
"commit": {
      "author": {
        "name": "Alan Hanson",
        "email": "alan@oxidecomputer.com",
        "date": "2021-05-08T00:29:44Z"
      },
      "committer": {
        "name": "Jess Frazelle",
        "email": "jessfraz@users.noreply.github.com",
        "date": "2021-05-08T17:45:44Z"
      }
}
```

If you look at the file history in GitHub it aligns with the `committer` dates

![image](https://user-images.githubusercontent.com/3087225/134370928-75701fd6-cde9-4896-97f9-0f25cb525fd2.png)
