### PR TITLE
Update cio schema to support rfd sections

### DIFF
--- a/cio/migrations/2021-10-01-231257_rfd_sections/up.sql
+++ b/cio/migrations/2021-10-01-231257_rfd_sections/up.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "rfd_sections" (
+    "id" SERIAL NOT NULL,
+    "anchor" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "rfds_id" INTEGER NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rfds.number_unique" ON "rfds"("number");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rfds.number_string_unique" ON "rfds"("number_string");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rfds.name_unique" ON "rfds"("name");
+
+-- AddForeignKey
+ALTER TABLE "sections" ADD FOREIGN KEY ("rfdsId") REFERENCES "rfds"("id") ON DELETE CASCADE ON UPDATE CASCADE

--- a/cio/src/schema.rs
+++ b/cio/src/schema.rs
@@ -797,6 +797,7 @@ table! {
         pdf_link_google_drive -> Varchar,
         cio_company_id -> Int4,
         airtable_record_id -> Varchar,
+        rfd_sections -> Array<Int4>,
     }
 }
 

--- a/cio/src/schema.rs
+++ b/cio/src/schema.rs
@@ -801,6 +801,16 @@ table! {
 }
 
 table! {
+    rfd_sections (id) {
+        id -> Int4,
+        name -> Varchar,
+        anchor -> Varchar,
+        content -> Text,
+        rfds_id -> Int4,
+    }
+}
+
+table! {
     software_vendors (id) {
         id -> Int4,
         name -> Varchar,

--- a/cio/src/schema.rs
+++ b/cio/src/schema.rs
@@ -797,7 +797,7 @@ table! {
         pdf_link_google_drive -> Varchar,
         cio_company_id -> Int4,
         airtable_record_id -> Varchar,
-        rfd_sections -> Array<Int4>,
+        rfd_sections_id -> Array<Int4>,
     }
 }
 


### PR DESCRIPTION
This is related to https://github.com/oxidecomputer/rfd/pull/319.

For proper full text search support we need documents to be broken down. Breaking things down by section provides a small enough surface area and a good mechanism for targeted linking. 