### PR TITLE
Add optional notes doc to calendar invites

### DIFF
--- a/cio/src/configs.rs
+++ b/cio/src/configs.rs
@@ -1335,6 +1335,8 @@ pub struct HuddleConfig {
     pub link_to_airtable_workspace: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub calendar_event_fuzzy_search: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub link_to_notes: String,
     #[serde(default)]
     pub time_to_cancel: i32,
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/cio/src/huddles.rs
+++ b/cio/src/huddles.rs
@@ -94,6 +94,12 @@ pub async fn sync_changes_to_google_events(db: &Database, company: &Company) -> 
                     discussion_topics = format!("Discussion topics:\n{}", discussion_topics);
                 }
 
+                let notes = if !huddle.link_to_notes.is_empty() {
+                    format!("Notes Doc: {}\n", huddle.link_to_notes)
+                } else {
+                    String::new()
+                };
+
                 // Update the event description.
                 let description = format!(
                     r#"This is the event for {} huddles.
@@ -102,12 +108,14 @@ You can submit topics at: https://{}-huddle-form.corp.{}
 
 The Airtable workspace lives at: https://{}-huddle.corp.{}
 
+{}
 {}"#,
                     slug.replace('-', " "),
                     slug,
                     company.domain,
                     slug,
                     company.domain,
+                    notes,
                     discussion_topics
                 );
 


### PR DESCRIPTION
Uses https://github.com/oxidecomputer/configs/pull/83 to populate notes doc, if present.