### PR TITLE
Add mermaid support to pdfs

### DIFF
--- a/.github/workflows/run-rfd-changelog.yaml
+++ b/.github/workflows/run-rfd-changelog.yaml
@@ -19,7 +19,7 @@ jobs:
             pandoc \
             poppler-utils \
             ruby
-          sudo gem install asciidoctor-pdf rouge
+          sudo gem install asciidoctor-pdf asciidoctor-mermaid rouge
       - name: Install SQL proxy
         shell: bash
         run: |

--- a/cio/src/rfds.rs
+++ b/cio/src/rfds.rs
@@ -561,7 +561,7 @@ impl RFD {
 
         let cmd_output = Command::new("asciidoctor-pdf")
             .current_dir(env::temp_dir())
-            .args(&["-o", "-", "-a", "source-highlighter=rouge", path.to_str().unwrap()])
+            .args(&["-o", "-", "-r", "asciidoctor-mermaid/pdf", "-a", "source-highlighter=rouge", path.to_str().unwrap()])
             .output()?;
 
         if !cmd_output.status.success() {

--- a/webhooky/Dockerfile
+++ b/webhooky/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN gem install \
 	asciidoctor-pdf \
+	asciidoctor-mermaid \
 	rouge
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
I've been working on [oxidecomputer/asciidoctor-mermaid](https://github.com/oxidecomputer/asciidoctor-mermaid) to compliment https://github.com/oxidecomputer/rfd/pull/375. Essentially we want mermaid diagrams to render in pdfs in the same way they render.

## Todo

- [ ] Add [`mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) as a project dependency