### PR TITLE
Fix mermaid-cli install

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,13 @@
 name: docker-image
 on:
+  pull_request:
+    paths:
+      - '**.rs'
+      - '*/Cargo.toml'
+      - 'Cargo.lock'
+      - .github/workflows/docker-image.yml
+      - rust-toolchain
+      - '*/Dockerfile'
   push:
     branches: master
     paths:

--- a/.github/workflows/run-rfd-changelog.yaml
+++ b/.github/workflows/run-rfd-changelog.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: actions/setup-node@v2
       - name: Install asciidoctor, pandoc, and pdftotext
         shell: bash
         run: |
@@ -19,9 +20,9 @@ jobs:
             pandoc \
             poppler-utils \
             ruby \
-            nodejs
           sudo gem install asciidoctor-pdf asciidoctor-mermaid rouge
-          npm install -g @mermaid-js/mermaid-cli
+          npm install @mermaid-js/mermaid-cli
+          ln -s ./node_modules/.bin/mmdc /usr/local/bin/mmdc
       - name: Install SQL proxy
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ rfd/
 brex.csv
 expensify.csv
 bill.com.csv
+
+node_modules
+package-lock.json
+package.json

--- a/webhooky/Dockerfile
+++ b/webhooky/Dockerfile
@@ -5,6 +5,8 @@ FROM ubuntu:latest AS app-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+WORKDIR /usr/src/webhooky
+
 RUN apt-get update && apt-get install -y \
 	asciidoctor \
 	ca-certificates \
@@ -46,7 +48,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN rustup default nightly
 
-WORKDIR /usr/src/webhooky
 
 # ------------------------------------------------------------------------------
 # Cargo Build Stage

--- a/webhooky/Dockerfile
+++ b/webhooky/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 	pandoc \
 	poppler-utils \
 	ruby \
-	npm \
+	curl \
     texlive-latex-base \
 	texlive-fonts-recommended \
 	texlive-fonts-extra \
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
-	sudo apt install -y --no-install-recommends \
+	apt install -y --no-install-recommends \
 	nodejs
 
 RUN gem install \

--- a/webhooky/Dockerfile
+++ b/webhooky/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
 	pandoc \
 	poppler-utils \
 	ruby \
-	nodejs \
 	npm \
     texlive-latex-base \
 	texlive-fonts-recommended \
@@ -25,12 +24,17 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+	sudo apt install -y --no-install-recommends \
+	nodejs
+
 RUN gem install \
 	asciidoctor-pdf \
 	asciidoctor-mermaid \
 	rouge
 
-RUN npm install -g @mermaid-js/mermaid-cli
+RUN npm install @mermaid-js/mermaid-cli && \
+	ln -s ./node_modules/.bin/mmdc /usr/local/bin/mmdc
 
 # ------------------------------------------------------------------------------
 # Cargo Nightly Stage


### PR DESCRIPTION
- Add better control of which node version is installed
- Install mermaid-cli locally to avoid weird perm issues