### PR TITLE
Added .githooks to share useful checks to run pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+HAS_ISSUES=0
+
+print_err () {
+  if [ $HAS_ISSUES -eq 0 ]; then
+    HAS_ISSUES=1
+    printf "The following files need formatting:\n"
+  fi  
+  printf " -> $1\n" 
+}
+
+# Check each changed file if it has formatting issues that need to be resolved
+for file in $(git diff --name-only --staged); do
+  FMT_RESULT="$(rustfmt --check $file 2>/dev/null || true)"
+  if [ "$FMT_RESULT" != "" ]; then
+      print_err $file 
+  fi
+done
+
+if [ $HAS_ISSUES -eq 1 ]; then
+  echo "Try fixing with 'cargo fmt'"
+  exit 1
+fi
+
+# Finish by running clippy
+cargo clippy -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+init:
+	git config core.hooksPath .githooks
+
 install-bitbar:
 	brew cask install bitbar
 	mkdir -p ~/.bitbar


### PR DESCRIPTION
After https://github.com/oxidecomputer/cio/pull/94 the code had to be formatted so I felt bad and made this.

This only formats files you changed to make the execution faster.

The following is an example output:

```
mig@ghost ~/Projects/cio$ git status
On branch add-git-hooks
Your branch is up to date with 'origin/add-git-hooks'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   shippo/src/lib.rs
	modified:   tailscale/src/lib.rs

no changes added to commit (use "git add" and/or "git commit -a")
mig@ghost ~/Projects/cio$ git add shippo/ tailscale/
mig@ghost ~/Projects/cio$ git commit -s
The following files need formatting:
 -> shippo/src/lib.rs
 -> tailscale/src/lib.rs
Try fixing with 'cargo fmt'
```

I wasn't sure about modifying the README to mention you need to run `make init` to set the githooks. There's no other way to check these into git.