### PR TITLE
Bump cloudflare to ^0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "cloudflare"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c17127dbdf8ba8654a984ed7eb7d5077e137c30e34d8c0a4212753426ea6f1b"
+checksum = "28a69d53c61ddd5611ad0203c60aa02074d67f91bfb98db2225833f6bdc2f1a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,9 +876,6 @@ dependencies = [
  "serde_json",
  "serde_qs 0.4.6",
  "serde_with",
- "slog",
- "slog-term",
- "sloggers",
  "url 2.2.2",
  "uuid",
 ]
@@ -2660,26 +2657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
-name = "libflate"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d57e534717ac3e0b8dc459fe338bdfb4e29d7eea8fd0926ba649ddd3f4765f"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
-dependencies = [
- "rle-decode-fast",
-]
-
-[[package]]
 name = "libnghttp2-sys"
 version = "0.1.7+1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,12 +4222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5188,16 +5159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog-kvfilter"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae939ed7d169eed9699f4f5cd440f046f5dc5dfc27c19e3cd311619594c175e0"
-dependencies = [
- "regex",
- "slog",
-]
-
-[[package]]
 name = "slog-scope"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5230,25 +5191,6 @@ dependencies = [
  "term",
  "thread_local",
  "time 0.3.7",
-]
-
-[[package]]
-name = "sloggers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01d37507aa6f37490cfa08d71e2639b16906e84c285ae4b9f7ec7ca35756d69"
-dependencies = [
- "chrono",
- "libflate",
- "regex",
- "serde",
- "slog",
- "slog-async",
- "slog-kvfilter",
- "slog-scope",
- "slog-stdlog",
- "slog-term",
- "trackable",
 ]
 
 [[package]]
@@ -5921,25 +5863,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "trackable"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017e2a1a93718e4e8386d037cfb8add78f1d690467f4350fb582f55af1203167"
-dependencies = [
- "trackable_derive",
-]
-
-[[package]]
-name = "trackable_derive"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
-dependencies = [
- "quote 1.0.16",
- "syn 1.0.89",
 ]
 
 [[package]]

--- a/cfcert/Cargo.toml
+++ b/cfcert/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-cloudflare = "^0.9.0"
+cloudflare = "^0.9.1"
 tokio = { version = "=1", features = ["full"] }

--- a/cio/Cargo.toml
+++ b/cio/Cargo.toml
@@ -28,7 +28,7 @@ checkr = "^0.0.10"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = "0.2.1"
 chrono-tz = { version = "0.6", features = ["serde"] }
-cloudflare = "^0.9.0"
+cloudflare = "^0.9.1"
 csv = "1.1"
 comrak = "0.12"
 deunicode = "1.3.0"

--- a/webhooky/Dockerfile
+++ b/webhooky/Dockerfile
@@ -69,6 +69,8 @@ COPY webhooky/src/dummy.rs ./src/dummy.rs
 
 COPY webhooky/Cargo.toml ./Cargo.toml
 
+COPY Cargo.lock ./Cargo.lock
+
 COPY rust-toolchain ./rust-toolchain
 
 # Move the deps we need to compile.


### PR DESCRIPTION
https://github.com/cloudflare/cloudflare-rs/pull/179 fixes the following error, which is preventing GCP console instances from starting up.

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value:
  Invalid(reqwest::Error { 
    kind: Decode,
    source: Error("missing field `wildcard_proxiable`", line: 1, column: 614)
  })', 
src/[main.rs:44](http://main.rs:44/):10
```

Not very cool for them to make API changes that break their own official client library!