### PR TITLE
Start fixing Airtable equivalence check failures

### DIFF
--- a/cio/src/recorded_meetings.rs
+++ b/cio/src/recorded_meetings.rs
@@ -46,7 +46,11 @@ use crate::{
 pub struct NewRecordedMeeting {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "String::is_empty",
+        deserialize_with = "crate::utils::trim"
+    )]
     pub description: String,
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,

--- a/cio/src/utils.rs
+++ b/cio/src/utils.rs
@@ -11,6 +11,7 @@ use octorust::Client as GitHub;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use reqwest::get;
 use sentry::IntoDsn;
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -468,6 +469,20 @@ pub async fn get_github_file(
 
             bail!("[rfd] getting file contents for {} failed: {}", file.path, e);
         }
+    }
+}
+
+pub fn trim<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    let trimmed = value.trim();
+
+    if value.len() != trimmed.len() {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(value)
     }
 }
 

--- a/cio/tests/airtable_equiv.rs
+++ b/cio/tests/airtable_equiv.rs
@@ -1,0 +1,10 @@
+use cio_api::recorded_meetings::RecordedMeeting;
+
+#[tokio::test]
+async fn test_airtable_row_equivalence() {
+    let db = cio_api::db::Database::new().await;
+    let db_meeting = RecordedMeeting::get_by_id(&db, 1070).await.unwrap();
+    let airtable_meeting = db_meeting.get_existing_airtable_record(&db).await.unwrap();
+
+    assert_eq!(db_meeting, airtable_meeting.fields);
+}


### PR DESCRIPTION
Long text fields from Airtable may differ from our internal representation as a result of trailing newlines. We want these to be considered equivalent.