### PR TITLE
Employee level materials

### DIFF
--- a/cio/migrations/2022-07-12-150519_add_materials_to_employees/down.sql
+++ b/cio/migrations/2022-07-12-150519_add_materials_to_employees/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN materials;

--- a/cio/migrations/2022-07-12-150519_add_materials_to_employees/up.sql
+++ b/cio/migrations/2022-07-12-150519_add_materials_to_employees/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN materials VARCHAR NOT NULL '';

--- a/cio/src/configs.rs
+++ b/cio/src/configs.rs
@@ -845,7 +845,8 @@ impl UserConfig {
             {
                 self.materials = applicant.materials;
             } else {
-                log::info!("Unable to find matching applicant when attempting to assign materials to employee {}", self.id);
+                // TODO: Change this so we are not logging usernames
+                log::info!("Unable to find matching applicant when attempting to assign materials to employee {}", self.username);
             }
         }
     }

--- a/cio/src/configs.rs
+++ b/cio/src/configs.rs
@@ -846,7 +846,10 @@ impl UserConfig {
                 self.materials = applicant.materials;
             } else {
                 // TODO: Change this so we are not logging usernames
-                log::info!("Unable to find matching applicant when attempting to assign materials to employee {}", self.username);
+                log::info!(
+                    "Unable to find matching applicant when attempting to assign materials to employee {}",
+                    self.username
+                );
             }
         }
     }

--- a/cio/src/interviews.rs
+++ b/cio/src/interviews.rs
@@ -344,28 +344,13 @@ pub async fn compile_packets(db: &Database, company: &Company) -> Result<()> {
             continue;
         }
 
-        // Get their application materials.
-        let mut materials_url = "".to_string();
-        if let Ok(a) = applicants::dsl::applicants
-            .filter(applicants::dsl::email.eq(employee.recovery_email.to_string()))
-            .first_async::<Applicant>(db.pool())
-            .await
-        {
-            materials_url = a.materials;
-        }
-
-        if materials_url.is_empty() {
-            if employee.username == "ben.leonard" {
-                // Add Ben's materials.
-                materials_url = "https://drive.google.com/open?id=1bOHalcpSyXwaxr4E-_2LeT06HGXQCW0n".to_string();
-            } else {
-                info!("could not find materials for email {}", employee.recovery_email);
-                continue;
-            }
+        if employee.materials.is_empty() {
+            info!("could not find materials for employee {}", employee.id);
+            continue;
         }
 
         // Let's download the contents of their materials locally.
-        download_materials_as_pdf(&drive_client, &materials_url, &employee.username)
+        download_materials_as_pdf(&drive_client, &employee.materials, &employee.username)
             .await
             .map_err(|err| {
                 log::error!(

--- a/cio/src/schema.rs
+++ b/cio/src/schema.rs
@@ -908,6 +908,7 @@ table! {
         start_date -> Date,
         birthday -> Date,
         public_ssh_keys -> Array<Text>,
+        materials -> Varchar,
         typev -> Varchar,
         google_anniversary_event_id -> Varchar,
         email -> Varchar,


### PR DESCRIPTION
Materials get parsed and attached to applicants when they first apply. When an applicant is transitioned to an employee, the link to those materials is not carried forward. To find the materials for an employee the `recovery_email` is used to look up a connection back to the original applicant.

This change updates the employee type to store the materials link directly with the employee. After adding this, the `recovery_email` lookup will be used as a fallback to populate the materials link.