### PR TITLE
[airtable-api] Add `delete_records` method for bulk deleting records

### DIFF
--- a/airtable/src/lib.rs
+++ b/airtable/src/lib.rs
@@ -254,6 +254,35 @@ impl Airtable {
         Ok(())
     }
 
+    /// Delete multiple records from a table.
+    ///
+    /// Due to limitations on the Airtable API, you can only bulk delete 10
+    /// records at a time.
+    pub async fn delete_records(&self, table: &str, record_ids: impl IntoIterator<Item = &str>) -> Result<()> {
+        // Build the request.
+        let request = self.request(
+            Method::DELETE,
+            table.to_string(),
+            (),
+            Some(
+                record_ids
+                    .into_iter()
+                    .map(|record_id| ("records[]", record_id.to_string()))
+                    .collect(),
+            ),
+        )?;
+
+        let resp = self.client.execute(request).await?;
+        match resp.status() {
+            StatusCode::OK => (),
+            s => {
+                bail!("status code: {}, body: {}", s, resp.text().await?);
+            }
+        };
+
+        Ok(())
+    }
+
     /// Bulk create records in a table.
     ///
     /// Due to limitations on the Airtable API, you can only bulk create 10


### PR DESCRIPTION
In my project, I found it necessary to delete many records in our Airtable base at once. Therefore, I added a method in the Airtable client for deleting multiple requests of the signature 
```rust
async fn delete_records(&self, table: &str, record_ids: impl IntoIterator<Item = &str>) -> Result<()>
```

Super simple addition, but hopefully this will prove useful to others :)