### PR TITLE
Shippo add parcel "extra" field for insurance rates.

### DIFF
--- a/shippo/src/lib.rs
+++ b/shippo/src/lib.rs
@@ -872,10 +872,10 @@ pub struct Insurance {
     /// "USD" | "CAD", etc.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub currency: String,
-    /// A short description of the contents of the parcel or shipment.
-    /// "5 t-shirts"
+    /// The shipping insurance provider.
+    /// "FEDEX" | "UPS"
     #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub content: String,
+    pub provider: String,
 }
 
 /// The data type for a rate.

--- a/shippo/src/lib.rs
+++ b/shippo/src/lib.rs
@@ -657,6 +657,9 @@ pub struct Shipment {
     /// Indicates whether the object has been created in test mode.
     #[serde(default)]
     pub test: bool,
+    /// Add extra options to the parcel request, such as shipping insurance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<Extra>,
 }
 
 /// The data type for a carrier account.
@@ -840,6 +843,39 @@ pub struct Parcel {
     /// Indicates whether the object has been created in test mode.
     #[serde(default)]
     pub test: bool,
+    /// Add extra options to the parcel request, such as shipping insurance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<Extra>,
+}
+
+/// The data type for extra Parcel or Shipment features, such as requesting
+/// insurance rates.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Extra {
+    /// Add extra insurance to the parcel or shipment.
+    /// If there's more than one parcel in the shipment,
+    /// you have to request insurance per-parcel on the
+    /// Parcel struct, otherwise, you can request it on
+    /// the Shipment struct instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub insurance: Option<Insurance>,
+}
+
+/// The data type for requesting shipping rates with extra insurance.
+/// FROM: https://goshippo.com/docs/insurance/
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Insurance {
+    /// The value of the parcel or shipment to insure.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub amount: String,
+    /// The currency to use for the previous amount value.
+    /// "USD" | "CAD", etc.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub currency: String,
+    /// A short description of the contents of the parcel or shipment.
+    /// "5 t-shirts"
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub content: String,
 }
 
 /// The data type for a rate.

--- a/shippo/src/lib.rs
+++ b/shippo/src/lib.rs
@@ -867,7 +867,7 @@ pub struct Extra {
 pub struct Insurance {
     /// The value of the parcel or shipment to insure.
     #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub amount: String,
+    pub amount: f64,
     /// The currency to use for the previous amount value.
     /// "USD" | "CAD", etc.
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/shippo/src/lib.rs
+++ b/shippo/src/lib.rs
@@ -866,7 +866,7 @@ pub struct Extra {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Insurance {
     /// The value of the parcel or shipment to insure.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[serde(default)]
     pub amount: f64,
     /// The currency to use for the previous amount value.
     /// "USD" | "CAD", etc.


### PR DESCRIPTION
Fixes #282 

Add optional "extra" field to Parcel and Shipment structs, and create Extra and Insurance structs.

I wanted to be able to request shipping rates with insurance, so I added this "extra" field as an Option<Extra> type.

Unfortunately Shippo will only add the insurance rates to the price for one carrier which you have to specify in the Parcel extra.provider field, and it only supports "UPS" or "FEDEX", so if your Shippo account has more than one carrier enabled and rates are returned from multiple carriers, the other carrier rates will be returned without any insurance amount added, which isn't ideal.

It's possible to request insurance rates from a different insurance company affiliated with Shippo, on the Shipment struct's "extra" field, however I'm not using this personally and not supporting it properly in this PR, because it needs a slightly different Insurance struct with the "amount" field being a String, and instead of the "provider" field, it needs a "content": String field.

Since I wanted to buy insurance from FedEx or UPS and not Shippo's provider, I didn't feel like properly supporting the "extra" field on the Shipment struct. It would be very easy to fix this though.

See for details: https://goshippo.com/docs/insurance/