### PR TITLE
RFD changelog email links to RFD site instead of short link -> GH

### DIFF
--- a/cio/src/rfd/changelog.rs
+++ b/cio/src/rfd/changelog.rs
@@ -28,8 +28,9 @@ pub async fn send_rfd_changelog(db: &Database, company: &Company) -> Result<()> 
     // Iterate over the RFDs.
     for rfd in rfds {
         let changes = rfd.get_weekly_changelog(&github, seven_days_ago, company).await?;
+        let url = format!("https://rfd.shared.oxide.computer/rfd/{}", rfd.number_string);
         if !changes.is_empty() {
-            changelog += &format!("\n{} {}\n{}", rfd.name, rfd.short_link, changes);
+            changelog += &format!("\n{} {}\n{}", rfd.name, url, changes);
         }
     }
 


### PR DESCRIPTION
This is a hack — another way of doing it would be to change the short link to point to the RFD site instead. That _would_ be smart, except that we are relying on that going to GH in some places ([example](https://github.com/oxidecomputer/rfd-site/blob/0ba5f719967f512f378f0237d268cf67c7c6a090/app/components/rfd/MoreDropdown.tsx#L34)). I assume that is not the only case.